### PR TITLE
Add ability to encrypt excel files [SC-SC-203035]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Version 1.0.2](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.2) - Feature release - 2024-05
+
+- Features added
+  - Ability to specify a password to encrypt Excel files
+
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.1) - Feature release - 2024-04
 
 - Recipe configurations saved in version 1.0.0 with "Attachments format" set to "Nothing selected" will no longer send CSV attachments.

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.json
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.json
@@ -205,6 +205,14 @@
         },
 
         {
+            "name": "encryption_password_excel",
+            "label" : "Encryption password",
+            "type": "STRING",
+            "description" : "(Optional) Password to encrypt excel files, requires DSS 13.0 or above",
+            "visibilityCondition" : "model.attachment_type == 'excel_can_ac'"
+        },
+
+        {
             "name": "sep_cond_format",
             "label": "Conditional formatting",
             "type": "SEPARATOR",

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.json
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.json
@@ -207,7 +207,7 @@
         {
             "name": "encryption_password_excel",
             "label" : "Encryption password",
-            "type": "STRING",
+            "type": "PASSWORD",
             "description" : "(Optional) Password to encrypt excel files, requires DSS 13.0 or above",
             "visibilityCondition" : "model.attachment_type == 'excel_can_ac'"
         },

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -73,6 +73,7 @@ mail_channel = config.get('mail_channel', None)
 channel_has_sender = does_channel_have_sender(mail_channel)
 
 attachment_type = config.get('attachment_type', "send_no_attachments")
+encryption_password_excel = config.get('encryption_password_excel', None)
 
 # Validation part 1 - Check some kind of value/column exists for body, subject, sender and recipient
 
@@ -139,7 +140,7 @@ output_schema.append({'name': 'sendmail_status', 'type': 'string'})
 output_schema.append({'name': 'sendmail_error', 'type': 'string'})
 output.write_schema(output_schema)
 
-attachment_files = build_attachment_files(attachment_datasets, attachment_type, apply_coloring_excel)
+attachment_files = build_attachment_files(attachment_datasets, attachment_type, apply_coloring_excel, encryption_password_excel)
 
 attachments_templating_dict = attachments_template_dict(attachment_datasets, project_key, apply_coloring_excel)
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sendmail",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"meta": {
 		"label": "Send emails",
 		"description": "Send emails based on a dataset containing a list of contacts, with optional attachments (other datasets)",

--- a/python-lib/dku_attachment_handling.py
+++ b/python-lib/dku_attachment_handling.py
@@ -35,7 +35,7 @@ def attachments_template_dict(attachment_datasets, home_project_key, apply_color
     return attachments_dict
 
 
-def build_attachment_files(attachment_datasets, attachment_type, apply_coloring_excel):
+def build_attachment_files(attachment_datasets, attachment_type, apply_coloring_excel, encryption_password_excel):
     """
         :param attachment_datasets: List of attachment datasets
         :param attachment_type: str, e.g. "excel", "csv" - "excel_can_ac" is treated as excel, "send_no_attachments" means none
@@ -54,6 +54,10 @@ def build_attachment_files(attachment_datasets, attachment_type, apply_coloring_
         request_fmt = "excel"
         if apply_coloring_excel and attachment_type == "excel_can_ac":
             format_params = {"applyColoring": True}
+        if encryption_password_excel:
+            if format_params is None:
+                format_params = {}
+            format_params["password"] = encryption_password_excel
     else:
         request_fmt = "tsv-excel-header"
 


### PR DESCRIPTION
**Important - Requires this PR on the DSS side:** https://github.com/dataiku/dip/pull/28735

![image](https://github.com/dataiku/dss-plugin-sendmail/assets/12499446/5e1cac2c-4b6a-4bf1-ad3b-4949e53baf4f)

**Note:** I couldn't find a way to have the "Encryption password" field appear only with DSS 13.0+. 
If you know how to do it, here is simple method to plug

```
def supports_encryption_password_excel(dss_client):
    # Check that the version of DSS is above 13.0 where this feature has been introduced
    try:
        return int(dss_client.get_instance_info().raw["dssVersion"].split(".")[0]) >= 13
    except ValueError:
        return False
```
