### PR TITLE
Support for sending email to multiple recipients.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.2](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.2) - Feature release - 2024-04
+
+- Support for sending emails to multiple recipients
+
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.1) - Feature release - 2024-04
 
 - Please read if upgrading from version 1.0.0 of the plugin

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -6,6 +6,8 @@ from dss_selector_choices import SENDER_SUFFIX
 from dku_attachment_handling import build_attachment_files, attachments_template_dict
 from email_utils import build_email_subject, build_email_message_text
 from jinja2 import Environment, StrictUndefined
+import json
+import collections.abc
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
@@ -33,6 +35,17 @@ def to_real_channel_id(channel_id):
 def does_channel_have_sender(channel_id):
     return channel_id is not None and channel_id.endswith(SENDER_SUFFIX)
 
+def parse_recipients(recipients):
+    try:
+        value = json.loads(recipients)
+        if isinstance(value, collections.abc.Sequence) and not isinstance(value, (str)):
+            #value is an array
+            return value
+        else:
+            return [value]
+    except json.decoder.JSONDecodeError:
+        pass
+    return recipients.split(",")
 
 # Get handles on datasets
 output_A_names = get_output_names_for_role('output')
@@ -155,8 +168,8 @@ with output.get_writer() as writer:
     fail = 0
     try:
         for contact in people.iter_rows():
-            recipient = contact[recipient_column]
-            if recipient:
+            recipients = contact[recipient_column]
+            if recipients:
                 logging.info("Sending to %s" % contact[recipient_column])
             else:
                 logging.info("No recipient for row - emailing will fail - row data: %s" % contact)
@@ -165,10 +178,11 @@ with output.get_writer() as writer:
                 email_subject = build_email_subject(use_subject_value, subject_template, subject_column, contact_dict)
                 email_body_text = build_email_message_text(use_body_value, body_template, attachments_templating_dict, contact_dict, body_column,
                                                          use_html_body_value)
-                recipient = contact_dict[recipient_column]
+                #recipients = contact_dict[recipient_column]
+                recipients = parse_recipients(recipients)
                 # Note - if the channel has a sender configured, the sender value will be ignored by the email client here
                 sender = sender_value if use_sender_value else contact_dict.get(sender_column, "")
-                email_client.send_email(sender, recipient, email_subject, email_body_text, attachment_files)
+                email_client.send_email(sender, recipients, email_subject, email_body_text, attachment_files)
 
                 contact_dict['sendmail_status'] = 'SUCCESS'
                 success += 1

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sendmail",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"meta": {
 		"label": "Send emails",
 		"description": "Send emails based on a dataset containing a list of contacts, with optional attachments (other datasets)",


### PR DESCRIPTION
This PR allow to support to send email to multiple recipients.
Supported formats are:
`recipient`
`recipient1, recipient2`
`["recipient1", "recipient2"]`

DISCLAIMER: This PR can't be merged for now as the DSS Notification API, even if it takes an array of recipients to send a email, sends one email to each recipents. With Inline SMTP the behaviour is corrected, the same email is sent to all the recipients 