### PR TITLE
Handle channels with useCurrentUserAsSender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Version 1.0.2](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.2) - Feature release - 2024-11
+
+- Features added
+  - Gracefully handle channels where "Use current user as sender" is set.
+
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.1) - Feature release - 2024-04
 
 - Please read if upgrading from version 1.0.0 of the plugin

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -95,14 +95,6 @@ else:
 if not is_subject_present:
     raise AttributeError("No value provided for the subject")
 
-is_sender_present = False
-if use_sender_value:
-    is_sender_present = bool(sender_value)
-else:
-    is_sender_present = bool(sender_column)
-if not (channel_has_sender or is_sender_present):
-    raise AttributeError("No value provided for the sender")
-
 if not recipient_column:
     raise AttributeError("No value provided for the recipient")
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sendmail",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"meta": {
 		"label": "Send emails",
 		"description": "Send emails based on a dataset containing a list of contacts, with optional attachments (other datasets)",

--- a/resource/dynamic_form.py
+++ b/resource/dynamic_form.py
@@ -13,11 +13,14 @@ def do(payload, config, plugin_config, inputs):
         if supports_messaging_channels_and_conditional_formatting(dss_client):
             channels = dss_client.list_messaging_channels(as_type="objects", channel_family="mail")
         for channel in channels:
-            if channel.sender:
+            if 'use_current_user_as_sender' in dir(channel) and channel.use_current_user_as_sender:
+                # If the channel has a locked-down sender using current user, append `(user email)` to label and SENDER_SUFFIX flag to channel ID
+                choices.append(f"{channel.id} (user email)", channel.id + SENDER_SUFFIX)
+            elif channel.sender:
                 # If the channel has a sender append `(<sender email>)` to label and SENDER_SUFFIX flag to channel ID
                 choices.append(f"{channel.id} ({channel.sender})", channel.id + SENDER_SUFFIX)
             else:
-                choices.append(f"{channel.id}",  channel.id)
+                choices.append(f"{channel.id}", channel.id)
 
         # Add an entry for direct SMTP
         if len(channels) > 0:


### PR DESCRIPTION
Add an option to user email of the current user when sending mail using this plugin.
(The plugin version 1.0.1 will work with the newly added feature, but will display the email of the default sender rather than `user email`)

**Version 1.0.2**
![image](https://github.com/user-attachments/assets/69c636f3-004b-4904-90c5-e1cfb5147939)

**Version 1.0.1**
![image](https://github.com/user-attachments/assets/778dc93a-18a2-4056-a7a7-ca09e047f56f)

With both versions of the plugin, the mail will be actually sent using the email address of the user running the recipe.