### PR TITLE
Feature/dss13 sc 219699 sendmail ability to send to multiple recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.2](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.2) - Feature release - 2024-04
+
+- Support for sending emails to multiple recipients
+
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.1) - Feature release - 2024-04
 
 - Please read if upgrading from version 1.0.0 of the plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [Version 1.0.2](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.2) - Feature release - 2024-04
+## [Version 1.0.2](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.2) - Feature release - 2025-03
 
-- Support for sending emails to multiple recipients
+- Support for sending emails to multiple recipients (a separate email is sent per recipient in recipient column)
 
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.1) - Feature release - 2024-04
 

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -6,6 +6,8 @@ from dss_selector_choices import SENDER_SUFFIX
 from dku_attachment_handling import build_attachment_files, attachments_template_dict
 from email_utils import build_email_subject, build_email_message_text
 from jinja2 import Environment, StrictUndefined
+import json
+import collections.abc
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
@@ -33,6 +35,17 @@ def to_real_channel_id(channel_id):
 def does_channel_have_sender(channel_id):
     return channel_id is not None and channel_id.endswith(SENDER_SUFFIX)
 
+def parse_recipients(recipients):
+    try:
+        value = json.loads(recipients)
+        if isinstance(value, collections.abc.Sequence) and not isinstance(value, (str)):
+            #value is an array
+            return value
+        else:
+            return [value]
+    except json.decoder.JSONDecodeError:
+        pass
+    return recipients.split(",")
 
 # Get handles on datasets
 output_A_names = get_output_names_for_role('output')
@@ -155,8 +168,8 @@ with output.get_writer() as writer:
     fail = 0
     try:
         for contact in people.iter_rows():
-            recipient = contact[recipient_column]
-            if recipient:
+            recipients = contact[recipient_column]
+            if recipients:
                 logging.info("Sending to %s" % contact[recipient_column])
             else:
                 logging.info("No recipient for row - emailing will fail - row data: %s" % contact)
@@ -165,10 +178,11 @@ with output.get_writer() as writer:
                 email_subject = build_email_subject(use_subject_value, subject_template, subject_column, contact_dict)
                 email_body_text = build_email_message_text(use_body_value, body_template, attachments_templating_dict, contact_dict, body_column,
                                                          use_html_body_value)
-                recipient = contact_dict[recipient_column]
+                #recipients = contact_dict[recipient_column]
+                recipients = parse_recipients(recipients)
                 # Note - if the channel has a sender configured, the sender value will be ignored by the email client here
                 sender = sender_value if use_sender_value else contact_dict.get(sender_column, "")
-                email_client.send_email(sender, recipient, email_subject, email_body_text, attachment_files)
+                email_client.send_email(sender, recipients, email_subject, email_body_text, attachment_files)
 
                 contact_dict['sendmail_status'] = 'SUCCESS'
                 success += 1

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sendmail",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"meta": {
 		"label": "Send emails",
 		"description": "Send emails based on a dataset containing a list of contacts, with optional attachments (other datasets)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sendmail",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"meta": {
 		"label": "Send emails",
 		"description": "Send emails based on a dataset containing a list of contacts, with optional attachments (other datasets)",

--- a/python-lib/dku_email_client.py
+++ b/python-lib/dku_email_client.py
@@ -44,13 +44,14 @@ class AbstractMessageClient(ABC):
         self.plain_text = plain_text
 
     @abstractmethod
-    def send_email(self,  sender, recipiens, email_body, email_subject, attachment_files):
+    def send_email(self, sender, recipients, email_body, email_subject, attachment_files):
         """
+        Sends a separate email to each recipient
         :param sender: sender email, str - is ignored if a sender configured for the channel
-        :param recipients: recipients email, Seq
+        :param recipients: recipients email addresses, list
         :param email_subject: str
         :param email_body: body of either plain text or html, str
-        :param attachment_files:attachments as list of  AttachmentFile
+        :param attachment_files:attachments as list of AttachmentFile
         """
         pass
 
@@ -80,11 +81,10 @@ class ChannelClient(AbstractMessageClient):
                      f"sender: {self.channel.sender}, plain_text? {self.plain_text}")
 
     def send_email(self, sender, recipients, email_subject, email_body, attachment_files):
-
         files = [(a.file_name, a.data, f"{a.mime_type}/{a.mime_subtype}") for a in attachment_files]
-
         sender_to_use = None if self.channel.sender else sender
-        self.channel.send(self.project_id, recipients, email_subject, email_body, attachments=files, plain_text=self.plain_text, sender=sender_to_use)
+        for recipient in recipients:
+            self.channel.send(self.project_id, [recipient], email_subject, email_body, attachments=files, plain_text=self.plain_text, sender=sender_to_use)
 
 
 class SmtpEmailClient(AbstractMessageClient):
@@ -113,14 +113,13 @@ class SmtpEmailClient(AbstractMessageClient):
             logging.info(f"Authenticated against STMP mail client")
 
 
-    def send_email(self, sender, recipients, email_subject, email_body, attachment_files):
-        msg = MIMEMultipart()
-        msg["From"] = sender
-        msg["To"] = ", ".join(recipients)
-        msg["Subject"] = email_subject
-        body_encoding = "utf-8"
-        text_type = 'plain' if self.plain_text else 'html'
-        msg.attach(MIMEText(email_body, text_type, body_encoding))
+
+    def attachments_to_mime(self, attachment_files):
+        """
+        :param attachment_files:attachment_files as list of AttachmentFile
+        :returns: the MIME parts, list of MIMEBase
+        """
+        attachment_mimes = [];
         for attachment_file in attachment_files:
             if attachment_file.mime_type == "application":
                 mime_app = MIMEApplication(attachment_file.data, _subtype=attachment_file.mime_subtype)
@@ -129,8 +128,33 @@ class SmtpEmailClient(AbstractMessageClient):
             else:
                 raise Exception(f'Cannot handle mime type {attachment_file.mime_type}')
             mime_app.add_header("Content-Disposition", 'attachment', filename=attachment_file.file_name)
+            attachment_mimes.append(mime_app)
+        return attachment_mimes
+
+    def send_single_email(self, sender, recipients, email_subject, email_body, attachment_mimes):
+        """
+        Sends a separate email to each recipient
+        :param sender: sender email, str - is ignored if a sender configured for the channel
+        :param recipients: recipients email addresses, list
+        :param email_subject: str
+        :param email_body: body of either plain text or html, str
+        :param attachment_mimes, list of MIMEBase
+        """
+        msg = MIMEMultipart()
+        msg["From"] = sender
+        msg["To"] = ",".join(recipients)
+        msg["Subject"] = email_subject
+        body_encoding = "utf-8"
+        text_type = 'plain' if self.plain_text else 'html'
+        msg.attach(MIMEText(email_body, text_type, body_encoding))
+        for mime_app in attachment_mimes:
             msg.attach(mime_app)
         self.smtp.sendmail(sender, recipients, msg.as_string())
+
+    def send_email(self, sender, recipients, email_subject, email_body, attachment_files):
+        attachment_mimes = self.attachments_to_mime(attachment_files)
+        for recipient in recipients:
+            self.send_single_email(sender, [recipient], email_subject, email_body, attachment_mimes)
 
     def quit(self):
         """ Do any disconnection needed"""


### PR DESCRIPTION
To support to sending emails to multiple recipients.
Card:
https://app.shortcut.com/dataiku/story/219699/sendmail-ability-to-send-to-multiple-recipients

Supported formats are:
```
1. name@thingy.com  
2. name_1@thingy.com, name_2@thingy.com  
3. ["name_1@thingy.com", "name_2@thingy.com "]
```

This will always send a **separate email** to each recipient both for SMTP direct and using a channel. The code now explicitly sends separate emails for each recipient to make this clear and to ensure the behaviour is consistent between channels and SMTP direct.

Channels do not support sending a single email to multiple recipients so we cannot support that consistently yet - even a single request was made with an array of recipients, multiple emails would be sent. But we can change that behaviour later and then add an option in the plugin to sen the same email for multiple recipients - the code is written in a way to make it be easy to change the code in the plugin for that.
