### PR TITLE
Add cc bcc csv comma delimited V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 1.0.4]() - Custom feature release 2025-11
+## [Version 1.0.4]() - Feature release - 2025-11
 
 - Add comma-delimited CSV option
 - Add cc and bcc fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 1.0.3A]() - Custom feature release 2025-08
+## [Version 1.0.4]() - Custom feature release 2025-11
 
 - Add comma-delimited CSV option
 - Add cc and bcc fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 1.0.4]() - Feature release - 2025-11
+## [Version 1.0.4](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.4) - Feature release - 2025-12
 
 - Add comma-delimited CSV option
 - Add cc and bcc fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Version 1.0.3A]() - Custom feature release 2025-08
+
+- Add comma-delimited CSV option
+- Add cc and bcc fields
+- Allow inline values for Recipient, cc, bcc
 
 ## [Version 1.0.3](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.3) - Feature release - 2025-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Add comma-delimited CSV option
 - Add cc and bcc fields
-- Allow inline values for Recipient, cc, bcc
 
 ## [Version 1.0.3](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.3) - Feature release - 2025-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 1.0.4](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.0.4) - Feature release - 2025-12
+## [Version 1.1.0](https://github.com/dataiku/dss-plugin-sendmail/releases/tag/v1.1.0) - Feature release - 2026-01
 
 - Add comma-delimited CSV option
 - Add cc and bcc fields

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.json
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.json
@@ -119,14 +119,14 @@
             "label" : "cc (column)",
             "type": "COLUMN",
             "columnRole" : "contacts",
-            "description" : "Courtesy copy (comma-separated or array, from a column)"
+            "description" : "Courtesy copy (comma-separated or array, from a column). Note: Duplicate data will cause multiple emails."
         },
         {
             "name": "bcc_column",
             "label" : "bcc (column)",
             "type": "COLUMN",
             "columnRole" : "contacts",
-            "description" : "Blind courtesy copy (comma-separated or array, from a column)"
+            "description" : "Blind courtesy copy (comma-separated or array, from a column). Note: Duplicate data will cause multiple emails."
         },
         {
             "name": "subject_column",

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.json
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.json
@@ -84,15 +84,7 @@
             "type": "PASSWORD",
             "visibilityCondition" : "(model.mail_channel == null || model.mail_channel == '__DKU__DIRECT_SMTP__') && model.smtp_use_auth"
         },
-
-        {
-            "name": "recipient_column",
-            "label" : "Recipient (column)",
-            "type": "COLUMN",
-            "columnRole" : "contacts",
-            "description" : "Recipient of the email (from a column)",
-            "mandatory": true
-        },
+        // 2025-08-27 Andy Holst added cc and bcc fields, and adjusted display order
         {
             "name": "sender_column",
             "label" : "Sender (column)",
@@ -114,6 +106,28 @@
             "description" : "Use custom value",
             "type": "BOOLEAN",
             "visibilityCondition" : "!model.mail_channel.endsWith('__WITH_DEFINED_SENDER__')"
+        },
+        {
+            "name": "recipient_column",
+            "label" : "Recipient (column)",
+            "type": "COLUMN",
+            "columnRole" : "contacts",
+            "description" : "Recipient of the email (from a column)",
+            "mandatory": true
+        },
+        {
+            "name": "cc_column",
+            "label" : "cc (column)",
+            "type": "COLUMN",
+            "columnRole" : "contacts",
+            "description" : "Courtesy copy (from a column)"
+        },
+        {
+            "name": "bcc_column",
+            "label" : "bcc (column)",
+            "type": "COLUMN",
+            "columnRole" : "contacts",
+            "description" : "Blind courtesy copy (from a column)"
         },
         {
             "name": "subject_column",
@@ -194,7 +208,7 @@
             "label": "Attachments",
             "type": "SEPARATOR"
         },
-
+        // 2025-08-27 Andy Holst added CSV comma-delimited
         {
             "name": "attachment_type",
             "label" : "Attachments format",
@@ -202,7 +216,8 @@
             "selectChoices" : [
                 {"value": "send_no_attachments", "label": "Do not send attachments"},
                 {"value": "excel", "label": "Excel"},
-                {"value": "csv", "label": "CSV"}
+                {"value": "csv", "label": "CSV tab-delimited"},
+                {"value": "csv_comma", "label": "CSV comma-delimited"}
             ],
             "defaultValue" : "send_no_attachments",
             "description" : "File format for attachments"

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.json
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.json
@@ -84,7 +84,6 @@
             "type": "PASSWORD",
             "visibilityCondition" : "(model.mail_channel == null || model.mail_channel == '__DKU__DIRECT_SMTP__') && model.smtp_use_auth"
         },
-        // 2025-08-27 Andy Holst added cc and bcc fields, and adjusted display order
         {
             "name": "sender_column",
             "label" : "Sender (column)",

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.json
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.json
@@ -111,7 +111,7 @@
             "label" : "Recipient (column)",
             "type": "COLUMN",
             "columnRole" : "contacts",
-            "description" : "Recipient of the email (from a column)",
+            "description" : "Recipient(s) of the email (comma-separated or array, from a column)",
             "mandatory": true
         },
         {
@@ -119,14 +119,14 @@
             "label" : "cc (column)",
             "type": "COLUMN",
             "columnRole" : "contacts",
-            "description" : "Courtesy copy (from a column)"
+            "description" : "Courtesy copy (comma-separated or array, from a column)"
         },
         {
             "name": "bcc_column",
             "label" : "bcc (column)",
             "type": "COLUMN",
             "columnRole" : "contacts",
-            "description" : "Blind courtesy copy (from a column)"
+            "description" : "Blind courtesy copy (comma-separated or array, from a column)"
         },
         {
             "name": "subject_column",

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.json
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.json
@@ -207,7 +207,6 @@
             "label": "Attachments",
             "type": "SEPARATOR"
         },
-        // 2025-08-27 Andy Holst added CSV comma-delimited
         {
             "name": "attachment_type",
             "label" : "Attachments format",

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -34,25 +34,33 @@ def to_real_channel_id(channel_id):
 def does_channel_have_sender(channel_id):
     return channel_id is not None and channel_id.endswith(SENDER_SUFFIX)
 
-# Takes a string and returns a list of one or more address values
+# Takes a string and returns a list of address values, could be empty - any no blank/empty strings are filtered out
 def parse_recipients(recipients):
+    if not recipients:
+        # Handle None and empty strings quickly
+        return []
+    json_array_found = False
     try:
         # JSON array case
         value = json.loads(recipients)
         if isinstance(value, list):
-            return value
+            recipients_list = value
+            json_array_found = True
     except json.decoder.JSONDecodeError:
         pass
     # Other cases - either a single value or comma separated string `name@place.com, name2@place.com`
-    return recipients.split(",")
+    if not json_array_found:
+        recipients_list = recipients.split(",")
 
-# Validates that columns (eg recipient, cc, bcc) are string datatype
-def confirm_string_column(column_name, schema):
+    filter_out_blanks = lambda item: bool(item) and not (isinstance(item, (str)) and item.isspace())
+    filtered_list = list(filter(filter_out_blanks, recipients_list))
+    return filtered_list
+
+# Validates column exists in schema
+def confirm_column(column_name, schema):
     column = next(filter(lambda col: col['name'] == column_name, schema), None)
     if not column:
           raise AttributeError("The column you specified (%s) was not found." % column_name)
-    if column['type'] != 'string':
-        raise AttributeError("The column you specified (%s) was not datatype string." % column_name)
 
 # Get handles on datasets
 output_A_names = get_output_names_for_role('output')
@@ -97,7 +105,7 @@ channel_has_sender = does_channel_have_sender(mail_channel)
 
 attachment_type = config.get('attachment_type', "send_no_attachments")
 
-# Validation part 1 - Check some kind of value/column exists for body, subject, sender and recipient
+# Validation part 1 - Check some kind of value/column has been given for body, subject, sender and recipient
 
 is_body_present = False
 if use_body_value:
@@ -118,25 +126,37 @@ else:
 if not is_subject_present:
     raise AttributeError("No value provided for the subject")
 
+is_sender_present = False
+
+if channel_has_sender:
+    is_sender_present = True
+else:
+    if use_sender_value:
+        is_sender_present = bool(sender_value)
+    else:
+        is_sender_present = bool(sender_column)
+if not is_sender_present:
+    raise AttributeError("No value provided for the sender")
+
 if not recipient_column:
     raise AttributeError("No value provided for the recipient")
 
 
-# Validation part 2 - when necessary, check the columns given are present as string columns in the contacts (people) dataset
+# Validation part 2 - when necessary, check the columns given exist in the contacts (people) dataset
 people_schema = people.read_schema()
 for arg in ['subject', 'body']:
    if not globals()["use_" + arg + "_value"]:
-       confirm_string_column(globals()[arg + "_column"], people_schema)       
+       confirm_column(globals()[arg + "_column"], people_schema)       
 
 if not channel_has_sender and not use_sender_value:    
-   confirm_string_column(sender_column, people_schema)
+   confirm_column(sender_column, people_schema)
 
 for arg in [recipient_column, cc_column, bcc_column]:
    if not arg:
        # recipient_column would have previously failed in Validation Part 1
        pass
    else:
-       confirm_string_column(arg, people_schema)
+       confirm_column(arg, people_schema)
 
 # Create Jinja templates if needed
 
@@ -187,8 +207,8 @@ with output.get_writer() as writer:
                 email_body_text = build_email_message_text(use_body_value, body_template, attachments_templating_dict, contact_dict, body_column,
                                                          use_html_body_value)
                 recipients = parse_recipients(recipients_string)
-                cc_recipients = parse_recipients(cc_string) if cc_string else [""]
-                bcc_recipients = parse_recipients(bcc_string) if bcc_string else [""]  
+                cc_recipients = parse_recipients(cc_string)
+                bcc_recipients = parse_recipients(bcc_string)
                 
                 # Note - if the channel has a sender configured, the sender value will be ignored by the email client here
                 sender = sender_value if use_sender_value else contact_dict.get(sender_column, "")
@@ -200,7 +220,7 @@ with output.get_writer() as writer:
                 if writer:
                     writer.write_row_dict(contact_dict)
             except Exception as e:
-                logging.exception("Send failed")
+                logging.exception("Send failed: %s", str(e))
                 fail += 1
                 contact_dict['sendmail_status'] = 'FAILED'
                 contact_dict['sendmail_error'] = str(e)

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -46,6 +46,14 @@ def parse_recipients(recipients):
     # Other cases - either a single value or comma separated string `name@place.com, name2@place.com`
     return recipients.split(",")
 
+# Validates that columns (eg recipient, cc, bcc) are string datatype
+def confirm_string_column(column_name, schema):
+    column = next(filter(lambda col: col['name'] == column_name, schema), None)
+    if not column:
+          raise AttributeError("The column you specified (%s) was not found." % column_name)
+    if column['type'] != 'string':
+        raise AttributeError("The column you specified (%s) was not datatype string." % column_name)
+
 # Get handles on datasets
 output_A_names = get_output_names_for_role('output')
 output = dataiku.Dataset(output_A_names[0]) if len(output_A_names) > 0 else None
@@ -114,30 +122,21 @@ if not recipient_column:
     raise AttributeError("No value provided for the recipient")
 
 
-# Validation part 2 - when necessary, check the column values provided are in the contacts (people) dataset
-people_columns = [p['name'] for p in people.read_schema()]
+# Validation part 2 - when necessary, check the columns given are present as string columns in the contacts (people) dataset
+people_schema = people.read_schema()
 for arg in ['subject', 'body']:
-    if not globals()["use_" + arg + "_value"] and globals()[arg + "_column"] not in people_columns:
-        raise AttributeError("The column you specified for %s (%s) was not found." % (arg, globals()[arg + "_column"]))
+   if not globals()["use_" + arg + "_value"]:
+       confirm_string_column(globals()[arg + "_column"], people_schema)       
 
-if not channel_has_sender and not use_sender_value and sender_column not in people_columns:
-    raise AttributeError("The column you specified for sender (%s) was not found." % sender_column)
+if not channel_has_sender and not use_sender_value:    
+   confirm_string_column(sender_column, people_schema)
 
 for arg in [recipient_column, cc_column, bcc_column]:
-    if not arg:
-        # recipient_column would have previously failed in Validation Part 1
-        pass
-    elif arg not in people_columns:
-        raise AttributeError("The column you specified (%s) was not found." % arg)
-    
-# Validation part 3 - validate that recipient, cc, and bcc are string datatypes
-people_schema = people.read_schema()
-
-for check in [recipient_column, cc_column, bcc_column]:
-    for item in people_schema:
-        if item['name'] == check:
-            if item['type'] != 'string':
-                raise AttributeError("The column you specified for (%s) was not datatype string." % item['name'])
+   if not arg:
+       # recipient_column would have previously failed in Validation Part 1
+       pass
+   else:
+       confirm_string_column(arg, people_schema)
 
 # Create Jinja templates if needed
 

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -188,8 +188,8 @@ with output.get_writer() as writer:
                 email_body_text = build_email_message_text(use_body_value, body_template, attachments_templating_dict, contact_dict, body_column,
                                                          use_html_body_value)
                 recipients = parse_recipients(recipients_string)
-                cc_recipients = parse_recipients(cc_string) if cc_string else None
-                bcc_recipients = parse_recipients(bcc_string) if bcc_string else None  
+                cc_recipients = parse_recipients(cc_string) if cc_string else [""]
+                bcc_recipients = parse_recipients(bcc_string) if bcc_string else [""]  
                 
                 # Note - if the channel has a sender configured, the sender value will be ignored by the email client here
                 sender = sender_value if use_sender_value else contact_dict.get(sender_column, "")

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -59,7 +59,6 @@ config = get_recipe_config()
 
 recipient_column = config.get('recipient_column', None)
 
-# 2025-08-27 Andy Holst added cc and bcc fields
 cc_column = config.get('cc_column', None)
 bcc_column = config.get('bcc_column', None)
 
@@ -124,9 +123,21 @@ for arg in ['subject', 'body']:
 if not channel_has_sender and not use_sender_value and sender_column not in people_columns:
     raise AttributeError("The column you specified for sender (%s) was not found." % sender_column)
 
-if recipient_column not in people_columns:
-    raise AttributeError("The column you specified for recipient (%s) was not found." % recipient_column)
+for arg in [recipient_column, cc_column, bcc_column]:
+    if not arg:
+        # recipient_column would have previously failed in Validation Part 1
+        pass
+    elif arg not in people_columns:
+        raise AttributeError("The column you specified (%s) was not found." % arg)
+    
+# Validation part 3 - validate that recipient, cc, and bcc are string datatypes
+people_schema = people.read_schema()
 
+for check in [recipient_column, cc_column, bcc_column]:
+    for item in people_schema:
+        if item['name'] == check:
+            if item['type'] != 'string':
+                raise AttributeError("The column you specified for (%s) was not datatype string." % item['name'])
 
 # Create Jinja templates if needed
 
@@ -163,34 +174,27 @@ with output.get_writer() as writer:
     fail = 0
     try:
         for contact in people.iter_rows():
-            recipients_string = contact[recipient_column]
+            recipients_string = contact[recipient_column]            
+            cc_string = contact[cc_column] if cc_column else None
+            bcc_string = contact[bcc_column] if bcc_column else None
             if recipients_string:
                 logging.info("Sending to %s" % recipients_string)
             else:
                 logging.info("No recipient for row - emailing will fail - row data: %s" % contact)
             contact_dict = dict(contact)
-
-            # 2025-08-27 Andy Holst added cc and bcc fields
-            if cc_column:
-                cc_recipient = contact[cc_column] if contact[cc_column] != "" else None
-            else:
-                cc_recipient = None
-                
-            if bcc_column:
-                bcc_recipient = contact[bcc_column] if contact[bcc_column] != "" else None
-            else:
-                bcc_recipient = None
                 
             try:
                 email_subject = build_email_subject(use_subject_value, subject_template, subject_column, contact_dict)
                 email_body_text = build_email_message_text(use_body_value, body_template, attachments_templating_dict, contact_dict, body_column,
                                                          use_html_body_value)
                 recipients = parse_recipients(recipients_string)
+                cc_recipients = parse_recipients(cc_string) if cc_string else None
+                bcc_recipients = parse_recipients(bcc_string) if bcc_string else None  
+                
                 # Note - if the channel has a sender configured, the sender value will be ignored by the email client here
                 sender = sender_value if use_sender_value else contact_dict.get(sender_column, "")
 
-                # 2025-08-27 Andy Holst added cc and bcc fields
-                email_client.send_email(sender, recipients, cc_recipient, bcc_recipient, email_subject, email_body_text, attachment_files)
+                email_client.send_email(sender, recipients, cc_recipients, bcc_recipients, email_subject, email_body_text, attachment_files)
 
                 contact_dict['sendmail_status'] = 'SUCCESS'
                 success += 1

--- a/custom-recipes/send-mails-from-contacts-dataset/recipe.py
+++ b/custom-recipes/send-mails-from-contacts-dataset/recipe.py
@@ -59,6 +59,10 @@ config = get_recipe_config()
 
 recipient_column = config.get('recipient_column', None)
 
+# 2025-08-27 Andy Holst added cc and bcc fields
+cc_column = config.get('cc_column', None)
+bcc_column = config.get('bcc_column', None)
+
 sender_column = config.get('sender_column', None)
 sender_value = config.get('sender_value', None)
 use_sender_value = config.get('use_sender_value', False)
@@ -165,6 +169,18 @@ with output.get_writer() as writer:
             else:
                 logging.info("No recipient for row - emailing will fail - row data: %s" % contact)
             contact_dict = dict(contact)
+
+            # 2025-08-27 Andy Holst added cc and bcc fields
+            if cc_column:
+                cc_recipient = contact[cc_column] if contact[cc_column] != "" else None
+            else:
+                cc_recipient = None
+                
+            if bcc_column:
+                bcc_recipient = contact[bcc_column] if contact[bcc_column] != "" else None
+            else:
+                bcc_recipient = None
+                
             try:
                 email_subject = build_email_subject(use_subject_value, subject_template, subject_column, contact_dict)
                 email_body_text = build_email_message_text(use_body_value, body_template, attachments_templating_dict, contact_dict, body_column,
@@ -172,7 +188,9 @@ with output.get_writer() as writer:
                 recipients = parse_recipients(recipients_string)
                 # Note - if the channel has a sender configured, the sender value will be ignored by the email client here
                 sender = sender_value if use_sender_value else contact_dict.get(sender_column, "")
-                email_client.send_email(sender, recipients, email_subject, email_body_text, attachment_files)
+
+                # 2025-08-27 Andy Holst added cc and bcc fields
+                email_client.send_email(sender, recipients, cc_recipient, bcc_recipient, email_subject, email_body_text, attachment_files)
 
                 contact_dict['sendmail_status'] = 'SUCCESS'
                 success += 1

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sendmail",
-	"version": "1.0.3A",
+	"version": "1.0.4",
 	"meta": {
 		"label": "Send emails",
 		"description": "Send emails based on a dataset containing a list of contacts, with optional attachments (other datasets)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sendmail",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"meta": {
 		"label": "Send emails",
 		"description": "Send emails based on a dataset containing a list of contacts, with optional attachments (other datasets)",
@@ -8,7 +8,8 @@
 		"icon": "icon-envelope-alt",
 		"licenseInfo": "Apache Software License",
 		"url": "https://www.dataiku.com/dss/plugins/info/sendmail.html",
-		"tags": ["Marketing"],
-        "supportLevel": "NOT_SUPPORTED"
+		"tags": ["Productivity","Export"],
+        "supportLevel": "NOT_SUPPORTED",
+		"category": "Digital Marketing"
 	}
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "sendmail",
-	"version": "1.0.3",
+	"version": "1.0.3A",
 	"meta": {
 		"label": "Send emails",
 		"description": "Send emails based on a dataset containing a list of contacts, with optional attachments (other datasets)",

--- a/python-lib/dku_attachment_handling.py
+++ b/python-lib/dku_attachment_handling.py
@@ -53,37 +53,27 @@ def build_attachment_files(attachment_datasets, attachment_type, apply_coloring_
     # Still, if the config has "excel_can_ac" and is run from the flow, we want to treat as excel (it means the user saved in v1.0.0 and did not reopen it)
     is_excel = attachment_type == "excel" or attachment_type == "excel_can_ac"
 
-    # 2025-08-27 Andy Holst added handling of comma-delimited CSV export
-    is_tab_csv = attachment_type == "csv"
-
     format_params = None
     if is_excel:
         request_fmt = "excel"
         if apply_coloring_excel and supports_messaging_channels_and_conditional_formatting(dataiku.api_client()):
             format_params = {"applyColoring": True}
-    # 2025-08-27 Andy Holst added handling of comma-delimited CSV export
-    #else:
-    #    request_fmt = "tsv-excel-header"
-    elif is_tab_csv:
+    elif attachment_type == "csv_comma":
+        request_fmt = "csv"
+        format_params={"style": "excel", "separator": ",", "quoteChar" : "\"", "parseHeaderRow": True}
+    else:
         request_fmt = "tsv-excel-header"
 
     # Prepare attachments
     attachment_files = []
     for attachment_ds in attachment_datasets:
-        # 2025-08-27 Andy Holst added handling of comma-delimited CSV export
-        if is_excel | is_tab_csv:
-            with attachment_ds.raw_formatted_data(format=request_fmt, format_params=format_params) as stream:
-                file_bytes = stream.read()
-            if is_excel:
-                attachment_files.append(AttachmentFile(attachment_ds.full_name + ".xlsx", "application",
-                                                         "vnd.openxmlformats-officedocument.spreadsheetml.sheet", file_bytes))
-            else:
-                attachment_files.append(AttachmentFile(attachment_ds.full_name + ".csv", "text", "csv", file_bytes))
-        
-        # 2025-08-27 Andy Holst added handling of comma-delimited CSV export
+    for attachment_ds in attachment_datasets:
+        with attachment_ds.raw_formatted_data(format=request_fmt, format_params=format_params) as stream:
+            file_bytes = stream.read()
+        if is_excel:
+            attachment_files.append(AttachmentFile(attachment_ds.full_name + ".xlsx", "application",
+                                                     "vnd.openxmlformats-officedocument.spreadsheetml.sheet", file_bytes))
+            
         else:
-            attachment_df = attachment_ds.get_dataframe()
-            csv_data = attachment_df.to_csv(index = False)
-            attachment_files.append(AttachmentFile(attachment_ds.full_name + ".csv", "text", "csv", csv_data))
-    
+            attachment_files.append(AttachmentFile(attachment_ds.full_name + ".csv", "text", "csv", file_bytes))
     return attachment_files

--- a/python-lib/dku_attachment_handling.py
+++ b/python-lib/dku_attachment_handling.py
@@ -53,22 +53,37 @@ def build_attachment_files(attachment_datasets, attachment_type, apply_coloring_
     # Still, if the config has "excel_can_ac" and is run from the flow, we want to treat as excel (it means the user saved in v1.0.0 and did not reopen it)
     is_excel = attachment_type == "excel" or attachment_type == "excel_can_ac"
 
+    # 2025-08-27 Andy Holst added handling of comma-delimited CSV export
+    is_tab_csv = attachment_type == "csv"
+
     format_params = None
     if is_excel:
         request_fmt = "excel"
         if apply_coloring_excel and supports_messaging_channels_and_conditional_formatting(dataiku.api_client()):
             format_params = {"applyColoring": True}
-    else:
+    # 2025-08-27 Andy Holst added handling of comma-delimited CSV export
+    #else:
+    #    request_fmt = "tsv-excel-header"
+    elif is_tab_csv:
         request_fmt = "tsv-excel-header"
 
     # Prepare attachments
     attachment_files = []
     for attachment_ds in attachment_datasets:
-        with attachment_ds.raw_formatted_data(format=request_fmt, format_params=format_params) as stream:
-            file_bytes = stream.read()
-        if is_excel:
-            attachment_files.append(AttachmentFile(attachment_ds.full_name + ".xlsx", "application",
-                                                     "vnd.openxmlformats-officedocument.spreadsheetml.sheet", file_bytes))
+        # 2025-08-27 Andy Holst added handling of comma-delimited CSV export
+        if is_excel | is_tab_csv:
+            with attachment_ds.raw_formatted_data(format=request_fmt, format_params=format_params) as stream:
+                file_bytes = stream.read()
+            if is_excel:
+                attachment_files.append(AttachmentFile(attachment_ds.full_name + ".xlsx", "application",
+                                                         "vnd.openxmlformats-officedocument.spreadsheetml.sheet", file_bytes))
+            else:
+                attachment_files.append(AttachmentFile(attachment_ds.full_name + ".csv", "text", "csv", file_bytes))
+        
+        # 2025-08-27 Andy Holst added handling of comma-delimited CSV export
         else:
-            attachment_files.append(AttachmentFile(attachment_ds.full_name + ".csv", "text", "csv", file_bytes))
+            attachment_df = attachment_ds.get_dataframe()
+            csv_data = attachment_df.to_csv(index = False)
+            attachment_files.append(AttachmentFile(attachment_ds.full_name + ".csv", "text", "csv", csv_data))
+    
     return attachment_files

--- a/python-lib/dku_attachment_handling.py
+++ b/python-lib/dku_attachment_handling.py
@@ -61,12 +61,13 @@ def build_attachment_files(attachment_datasets, attachment_type, apply_coloring_
     elif attachment_type == "csv_comma":
         request_fmt = "csv"
         format_params={"style": "excel", "separator": ",", "quoteChar" : "\"", "parseHeaderRow": True}
+    
+    # We expect attachment_type == "csv" here, revisit if future types/options are added in future
     else:
         request_fmt = "tsv-excel-header"
 
     # Prepare attachments
     attachment_files = []
-    for attachment_ds in attachment_datasets:
     for attachment_ds in attachment_datasets:
         with attachment_ds.raw_formatted_data(format=request_fmt, format_params=format_params) as stream:
             file_bytes = stream.read()

--- a/python-lib/dku_email_client.py
+++ b/python-lib/dku_email_client.py
@@ -158,7 +158,7 @@ class SmtpEmailClient(AbstractMessageClient):
         msg["To"] = ",".join(recipients)
 
         msg["Cc"] = ",".join(cc_recipients)
-        all_recipients = [recipients] + cc_recipients + bcc_recipients
+        all_recipients = recipients + cc_recipients + bcc_recipients
         
         msg["Subject"] = email_subject
         body_encoding = "utf-8"

--- a/python-lib/dku_email_client.py
+++ b/python-lib/dku_email_client.py
@@ -43,15 +43,14 @@ class AbstractMessageClient(ABC):
     def __init__(self, plain_text):
         self.plain_text = plain_text
 
-    # 2025-08-27 Andy Holst added cc and bcc fields
     @abstractmethod
-    def send_email(self, sender, recipients, cc_recipient, bcc_recipient, email_body, email_subject, attachment_files):
+    def send_email(self, sender, recipients, cc_recipients, bcc_recipients, email_body, email_subject, attachment_files):
         """
         Sends a separate email to each recipient
         :param sender: sender email, str - is ignored if a sender configured for the channel
         :param recipients: recipients email addresses, list
-        :param cc_recipient: cc recipient email, str
-        :param bcc_recipient bcc recipient email, str
+        :param cc_recipients: cc recipient emails, list
+        :param bcc_recipients bcc recipient emails, list
         :param email_subject: str
         :param email_body: body of either plain text or html, str
         :param attachment_files:attachments as list of AttachmentFile
@@ -83,28 +82,20 @@ class ChannelClient(AbstractMessageClient):
         logging.info(f"Configured channel messaging client with channel {channel_id} - type: {self.channel.type}, "
                      f"sender: {self.channel.sender}, plain_text? {self.plain_text}")
     
-    # 2025-08-27 Andy Holst added cc and bcc fields
-    def send_email(self, sender, recipients, cc_recipient, bcc_recipient, email_subject, email_body, attachment_files):
+    def send_email(self, sender, recipients, cc_recipients, bcc_recipients, email_subject, email_body, attachment_files):
         files = [(a.file_name, a.data, f"{a.mime_type}/{a.mime_subtype}") for a in attachment_files]
         sender_to_use = None if self.channel.sender else sender
 
-        # 2025-08-27 Andy Holst added cc and bcc fields
-        cc_list = cc_recipient.split(",") if cc_recipient != None else []
-        bcc_list = bcc_recipient.split(",") if bcc_recipient != None else []
-
-        # 2025-08-27 Andy Holst added cc and bcc fields
         for recipient in recipients:
-            all_recipient = [recipient] + cc_list + bcc_list
-            self.channel.send(self.project_id, 
-                              all_recipient,
-                              #[recipient], 
+            self.channel.send(self.project_id,
+                              [recipient], 
                               email_subject, 
                               email_body, 
                               attachments=files, 
                               plain_text=self.plain_text, 
                               sender=sender_to_use,
-                              cc=cc_list,
-                              bcc=bcc_list)
+                              cc=cc_recipients,
+                              bcc=bcc_recipients)
 
 
 class SmtpEmailClient(AbstractMessageClient):
@@ -151,14 +142,13 @@ class SmtpEmailClient(AbstractMessageClient):
             attachment_mimes.append(mime_app)
         return attachment_mimes
 
-    # 2025-08-27 Andy Holst added cc and bcc fields
-    def send_single_email(self, sender, recipients, cc_recipient, bcc_recipient, email_subject, email_body, attachment_mimes):
+    def send_single_email(self, sender, recipients, cc_recipients, bcc_recipients, email_subject, email_body, attachment_mimes):
         """
         Sends a separate email to each recipient
         :param sender: sender email, str - is ignored if a sender configured for the channel
         :param recipients: recipients email addresses, list
-        :param cc_recipient: cc recipient email, str
-        :param bcc_recipient bcc recipient email, str
+        :param cc_recipients: cc recipient emails, list
+        :param bcc_recipients: bcc recipient emails, list
         :param email_subject: str
         :param email_body: body of either plain text or html, str
         :param attachment_mimes, list of MIMEBase
@@ -167,11 +157,8 @@ class SmtpEmailClient(AbstractMessageClient):
         msg["From"] = sender
         msg["To"] = ",".join(recipients)
 
-        # 2025-08-27 Andy Holst added cc and bcc fields
-        msg["Cc"] = cc_recipient
-        cc_list = cc_recipient.split(",") if cc_recipient != None else []
-        bcc_list = bcc_recipient.split(",") if bcc_recipient != None else []
-        all_recipient = [recipients] + cc_list + bcc_list
+        msg["Cc"] = ",".join(cc_recipients)
+        all_recipients = [recipients] + cc_recipients + bcc_recipients
         
         msg["Subject"] = email_subject
         body_encoding = "utf-8"
@@ -180,14 +167,12 @@ class SmtpEmailClient(AbstractMessageClient):
         for mime_app in attachment_mimes:
             msg.attach(mime_app)
 
-        # 2025-08-27 Andy Holst added cc and bcc fields
-        self.smtp.sendmail(sender, all_recipient, msg.as_string())
+        self.smtp.sendmail(sender, all_recipients, msg.as_string())
 
-    # 2025-08-27 Andy Holst added cc and bcc fields
-    def send_email(self, sender, recipients, cc_recipient, bcc_recipient, email_subject, email_body, attachment_files):
+    def send_email(self, sender, recipients, cc_recipients, bcc_recipients, email_subject, email_body, attachment_files):
         attachment_mimes = self.attachments_to_mime(attachment_files)
         for recipient in recipients:
-            self.send_single_email(sender, [recipient], cc_recipient, bcc_recipient, email_subject, email_body, attachment_mimes)
+            self.send_single_email(sender, [recipient], cc_recipients, bcc_recipients, email_subject, email_body, attachment_mimes)
 
     def quit(self):
         """ Do any disconnection needed"""

--- a/python-lib/dku_email_client.py
+++ b/python-lib/dku_email_client.py
@@ -43,12 +43,15 @@ class AbstractMessageClient(ABC):
     def __init__(self, plain_text):
         self.plain_text = plain_text
 
+    # 2025-08-27 Andy Holst added cc and bcc fields
     @abstractmethod
-    def send_email(self, sender, recipients, email_body, email_subject, attachment_files):
+    def send_email(self, sender, recipients, cc_recipient, bcc_recipient, email_body, email_subject, attachment_files):
         """
         Sends a separate email to each recipient
         :param sender: sender email, str - is ignored if a sender configured for the channel
         :param recipients: recipients email addresses, list
+        :param cc_recipient: cc recipient email, str
+        :param bcc_recipient bcc recipient email, str
         :param email_subject: str
         :param email_body: body of either plain text or html, str
         :param attachment_files:attachments as list of AttachmentFile
@@ -79,12 +82,29 @@ class ChannelClient(AbstractMessageClient):
 
         logging.info(f"Configured channel messaging client with channel {channel_id} - type: {self.channel.type}, "
                      f"sender: {self.channel.sender}, plain_text? {self.plain_text}")
-
-    def send_email(self, sender, recipients, email_subject, email_body, attachment_files):
+    
+    # 2025-08-27 Andy Holst added cc and bcc fields
+    def send_email(self, sender, recipients, cc_recipient, bcc_recipient, email_subject, email_body, attachment_files):
         files = [(a.file_name, a.data, f"{a.mime_type}/{a.mime_subtype}") for a in attachment_files]
         sender_to_use = None if self.channel.sender else sender
+
+        # 2025-08-27 Andy Holst added cc and bcc fields
+        cc_list = cc_recipient.split(",") if cc_recipient != None else []
+        bcc_list = bcc_recipient.split(",") if bcc_recipient != None else []
+
+        # 2025-08-27 Andy Holst added cc and bcc fields
         for recipient in recipients:
-            self.channel.send(self.project_id, [recipient], email_subject, email_body, attachments=files, plain_text=self.plain_text, sender=sender_to_use)
+            all_recipient = [recipient] + cc_list + bcc_list
+            self.channel.send(self.project_id, 
+                              all_recipient,
+                              #[recipient], 
+                              email_subject, 
+                              email_body, 
+                              attachments=files, 
+                              plain_text=self.plain_text, 
+                              sender=sender_to_use,
+                              cc=cc_list,
+                              bcc=bcc_list)
 
 
 class SmtpEmailClient(AbstractMessageClient):
@@ -131,11 +151,14 @@ class SmtpEmailClient(AbstractMessageClient):
             attachment_mimes.append(mime_app)
         return attachment_mimes
 
-    def send_single_email(self, sender, recipients, email_subject, email_body, attachment_mimes):
+    # 2025-08-27 Andy Holst added cc and bcc fields
+    def send_single_email(self, sender, recipients, cc_recipient, bcc_recipient, email_subject, email_body, attachment_mimes):
         """
         Sends a separate email to each recipient
         :param sender: sender email, str - is ignored if a sender configured for the channel
         :param recipients: recipients email addresses, list
+        :param cc_recipient: cc recipient email, str
+        :param bcc_recipient bcc recipient email, str
         :param email_subject: str
         :param email_body: body of either plain text or html, str
         :param attachment_mimes, list of MIMEBase
@@ -143,18 +166,28 @@ class SmtpEmailClient(AbstractMessageClient):
         msg = MIMEMultipart()
         msg["From"] = sender
         msg["To"] = ",".join(recipients)
+
+        # 2025-08-27 Andy Holst added cc and bcc fields
+        msg["Cc"] = cc_recipient
+        cc_list = cc_recipient.split(",") if cc_recipient != None else []
+        bcc_list = bcc_recipient.split(",") if bcc_recipient != None else []
+        all_recipient = [recipients] + cc_list + bcc_list
+        
         msg["Subject"] = email_subject
         body_encoding = "utf-8"
         text_type = 'plain' if self.plain_text else 'html'
         msg.attach(MIMEText(email_body, text_type, body_encoding))
         for mime_app in attachment_mimes:
             msg.attach(mime_app)
-        self.smtp.sendmail(sender, recipients, msg.as_string())
 
-    def send_email(self, sender, recipients, email_subject, email_body, attachment_files):
+        # 2025-08-27 Andy Holst added cc and bcc fields
+        self.smtp.sendmail(sender, all_recipient, msg.as_string())
+
+    # 2025-08-27 Andy Holst added cc and bcc fields
+    def send_email(self, sender, recipients, cc_recipient, bcc_recipient, email_subject, email_body, attachment_files):
         attachment_mimes = self.attachments_to_mime(attachment_files)
         for recipient in recipients:
-            self.send_single_email(sender, [recipient], email_subject, email_body, attachment_mimes)
+            self.send_single_email(sender, [recipient], cc_recipient, bcc_recipient, email_subject, email_body, attachment_mimes)
 
     def quit(self):
         """ Do any disconnection needed"""

--- a/python-lib/dku_email_client.py
+++ b/python-lib/dku_email_client.py
@@ -157,6 +157,8 @@ class SmtpEmailClient(AbstractMessageClient):
         msg["From"] = sender
         msg["To"] = ",".join(recipients)
 
+        # Note: bcc recipients are implicitly handled, by excluding from msg but including in all_recipients
+        # See: https://stackoverflow.com/questions/1546367/how-to-send-mail-with-to-cc-and-bcc#:~:text=2%20Comments-,Add%20a%20comment,is%20in%20textfile%20for%20reading.
         msg["Cc"] = ",".join(cc_recipients)
         all_recipients = recipients + cc_recipients + bcc_recipients
         

--- a/python-lib/dku_email_client.py
+++ b/python-lib/dku_email_client.py
@@ -86,6 +86,9 @@ class ChannelClient(AbstractMessageClient):
         files = [(a.file_name, a.data, f"{a.mime_type}/{a.mime_subtype}") for a in attachment_files]
         sender_to_use = None if self.channel.sender else sender
 
+        if not recipients:
+            raise Exception("No recipients provided to send to")
+
         for recipient in recipients:
             self.channel.send(self.project_id,
                               [recipient], 
@@ -169,10 +172,16 @@ class SmtpEmailClient(AbstractMessageClient):
         for mime_app in attachment_mimes:
             msg.attach(mime_app)
 
-        self.smtp.sendmail(sender, all_recipients, msg.as_string())
+        try:
+            self.smtp.sendmail(sender, all_recipients, msg.as_string())
+        finally:
+            # Explicitly reset the session or "Error: nested MAIL command" error is possible
+            self.smtp.rset()
 
     def send_email(self, sender, recipients, cc_recipients, bcc_recipients, email_subject, email_body, attachment_files):
         attachment_mimes = self.attachments_to_mime(attachment_files)
+        if not recipients:
+            raise Exception("No recipients provided to send to")
         for recipient in recipients:
             self.send_single_email(sender, [recipient], cc_recipients, bcc_recipients, email_subject, email_body, attachment_mimes)
 


### PR DESCRIPTION
@liamlynch-data - I created a clean, new pull request here.
(original PR [here](https://github.com/dataiku/dss-plugin-sendmail/pull/20) )

NOTES:

I did NOT incorporate changing to `SMTP.send_message(msg)`, for two reasons:

1. The `sendmail` method was selected by the Plugin dev team, so updates should probably best be led by them.
2. There may be some ramifications to how attachments are managed.

Also, I did not incorporate hard coded CC or BCC fields, primarily because the UI/UX gets really messy. Since "Recipient" field is always pulled from the dataset, then the best UI/UX is to also always pull the "cc" and "bcc" from the dataset as well.